### PR TITLE
Use keyframe index to set `animation.finished` instead of match arms

### DIFF
--- a/src/animation/animation_spritesheet.rs
+++ b/src/animation/animation_spritesheet.rs
@@ -62,27 +62,20 @@ fn apply_animation_player_spritesheet(
             elapsed += animation_clip.duration();
         }
 
-        animation.finished = false;
-
         let index = match animation_clip
             .keyframe_timestamps()
             .binary_search_by(|probe| probe.partial_cmp(&elapsed).unwrap())
         {
-            Ok(0) => 0, // this will probably the first frame in the paused state
-            Ok(n) if n >= animation_clip.keyframe_timestamps().len() - 1 => {
-                animation.finished = true;
-                return;
-            }
+            Ok(0) => 0, // this is probably the first frame in the paused state
+            Ok(n) if n >= animation_clip.keyframe_timestamps().len() - 1 => return,
             Ok(i) => i,
             Err(0) => return, // this clip isn't started yet
-            Err(n) if n > animation_clip.keyframe_timestamps().len() => {
-                animation.finished = true;
-                return;
-            }
+            Err(n) if n > animation_clip.keyframe_timestamps().len() => return,
             Err(i) => i - 1,
         };
 
         let keyframes = animation_clip.keyframes();
+        animation.finished = index == keyframes.len() - 1;
         *sprite_index = keyframes[index]
     }
 }


### PR DESCRIPTION
The changes introduces in #15 are actually not working correctly. The reason for that is that `Ok(n)` and `Err(n)` don't seem to fire on the last frames. This implementation does work, which is a bit confusing as the `return`s should prevent it from working.

Addresses #14.