### PR TITLE
Add a SystemSet for animations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,7 @@ path = "examples/sprite_sheet_animation_titan.rs"
 [[example]]
 name = "bevy_asset_loader"
 path = "examples/bevy_asset_loader.rs"
+
+[[example]]
+name = "pausing_animations"
+path = "examples/pausing_animations.rs"

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,9 +14,11 @@ Example                        | Description |
 [Sprite sheet animation]       | Shows of how to use `bevy_trickfilm` with a sprite sheet. |
 [Using bevy_titan]             | Simple example with [bevy_titan]. |
 [Using bevy_asset_loader]      | Simple example with [bevy_asset_loader]. |
+[Pausing animations]           | Simple example to show how to globally pause all animtions. |
 
-[Sprite sheet animation]: (examples/sprite_sheet_animation.rs)
-[Using bevy_titan]: (examples/sprite_sheet_animation_titan.rs)
-[Using bevy_asset_loader]: (examples/bevy_asset_loader.rs)
-[bevy_asset_loader]: (https://crates.io/crates/bevy_asset_loader)
-[bevy_titan]: (https://crates.io/crates/bevy_titan)
+[Sprite sheet animation]: ../examples/sprite_sheet_animation.rs
+[Using bevy_titan]: ../examples/sprite_sheet_animation_titan.rs
+[Using bevy_asset_loader]: ../examples/bevy_asset_loader.rs
+[Pausing animations]: ../examples/pausing_animations.rs
+[bevy_asset_loader]: https://crates.io/crates/bevy_asset_loader
+[bevy_titan]: https://crates.io/crates/bevy_titan

--- a/examples/pausing_animations.rs
+++ b/examples/pausing_animations.rs
@@ -1,0 +1,95 @@
+//! This example demonstrates how to pause or resume animations based on the supplied `State`.
+
+use bevy::{input::common_conditions::input_just_pressed, prelude::*};
+use bevy_trickfilm::{animation::AnimationPlayer2DSystemSet, prelude::*};
+
+/// This can also be done as a `SubState` or a `ComputedState`.
+/// We use `app.configure_sets()` to toggle [`AnimationPlayer2DSystemSet`] to
+/// only execute when we're in the `PauseState::Running` state.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, States)]
+pub enum PauseState {
+    #[default]
+    Running,
+    Paused,
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
+        .init_state::<PauseState>()
+        .configure_sets(
+            Update,
+            AnimationPlayer2DSystemSet.run_if(in_state(PauseState::Running)),
+        )
+        .add_plugins(Animation2DPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(
+            Update,
+            toggle_animation_pause.run_if(input_just_pressed(KeyCode::Space)),
+        )
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut texture_atlas_layouts: ResMut<Assets<TextureAtlasLayout>>,
+) {
+    let atlas_texture = asset_server.load("gabe-idle-run.png");
+    let texture_atlas_layout = TextureAtlasLayout::from_grid(UVec2::new(24, 24), 7, 1, None, None);
+    let texture_atlas = TextureAtlas {
+        layout: texture_atlas_layouts.add(texture_atlas_layout),
+        ..Default::default()
+    };
+
+    // Camera
+    commands.spawn(Camera2dBundle::default());
+
+    // Prepare AnimationPlayer
+    let animation = asset_server.load("gabe-idle-run.trickfilm#run");
+
+    let mut animation_player = AnimationPlayer2D::default();
+    animation_player.play(animation.clone()).repeat();
+
+    // SpriteSheet entity
+    commands
+        .spawn(SpriteBundle {
+            transform: Transform::from_scale(Vec3::splat(6.0)),
+            texture: atlas_texture,
+            ..Default::default()
+        })
+        .insert(texture_atlas)
+        .insert(animation_player);
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                position_type: PositionType::Absolute,
+                bottom: Val::Px(15.0),
+                left: Val::Px(15.0),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .with_children(|node| {
+            node.spawn(TextBundle {
+                text: Text::from_section(
+                    "Press SPACE to pause/unpause animation",
+                    TextStyle {
+                        font_size: 24.,
+                        ..Default::default()
+                    },
+                ),
+                ..Default::default()
+            });
+        });
+}
+
+fn toggle_animation_pause(
+    current_pause_state: Res<State<PauseState>>,
+    mut next_pause_state: ResMut<NextState<PauseState>>,
+) {
+    next_pause_state.set(match current_pause_state.get() {
+        PauseState::Running => PauseState::Paused,
+        PauseState::Paused => PauseState::Running,
+    });
+}

--- a/examples/pausing_animations.rs
+++ b/examples/pausing_animations.rs
@@ -1,7 +1,7 @@
 //! This example demonstrates how to pause or resume animations based on the supplied `State`.
 
 use bevy::{input::common_conditions::input_just_pressed, prelude::*};
-use bevy_trickfilm::{animation::AnimationPlayer2DSystemSet, prelude::*};
+use bevy_trickfilm::prelude::*;
 
 /// This can also be done as a `SubState` or a `ComputedState`.
 /// We use `app.configure_sets()` to toggle [`AnimationPlayer2DSystemSet`] to
@@ -60,28 +60,9 @@ fn setup(
         })
         .insert(texture_atlas)
         .insert(animation_player);
-    commands
-        .spawn(NodeBundle {
-            style: Style {
-                position_type: PositionType::Absolute,
-                bottom: Val::Px(15.0),
-                left: Val::Px(15.0),
-                ..Default::default()
-            },
-            ..Default::default()
-        })
-        .with_children(|node| {
-            node.spawn(TextBundle {
-                text: Text::from_section(
-                    "Press SPACE to pause/unpause animation",
-                    TextStyle {
-                        font_size: 24.,
-                        ..Default::default()
-                    },
-                ),
-                ..Default::default()
-            });
-        });
+
+    println!("Pasuing controls:");
+    println!("  - spacebar: play / pause");
 }
 
 fn toggle_animation_pause(

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -6,19 +6,27 @@ mod animation_spritesheet;
 use crate::prelude::AnimationClip2D;
 use bevy::{
     animation::RepeatAnimation,
-    prelude::{App, Component, Handle, Plugin, ReflectComponent, Update},
+    prelude::{
+        App, Component, Handle, IntoSystemConfigs, Plugin, ReflectComponent, SystemSet, Update,
+    },
     reflect::Reflect,
 };
 
 use self::animation_spritesheet::animation_player_spritesheet;
+
+/// A [`SystemSet`] to control where the animations are run
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AnimationPlayer2DSystemSet;
 
 /// Adds support for spritesheet animation playing.
 pub struct AnimationPlayer2DPlugin;
 
 impl Plugin for AnimationPlayer2DPlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<AnimationPlayer2D>()
-            .add_systems(Update, animation_player_spritesheet);
+        app.register_type::<AnimationPlayer2D>().add_systems(
+            Update,
+            animation_player_spritesheet.in_set(AnimationPlayer2DSystemSet),
+        );
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,9 @@ impl Plugin for Animation2DPlugin {
 
 /// `use bevy_trickfilm::prelude::*;` to import common components and plugins.
 pub mod prelude {
-    pub use crate::animation::{AnimationPlayer2D, AnimationPlayer2DPlugin};
+    pub use crate::animation::{
+        AnimationPlayer2D, AnimationPlayer2DPlugin, AnimationPlayer2DSystemSet,
+    };
     pub use crate::asset::{Animation2DLoaderPlugin, AnimationClip2D, AnimationClip2DSet};
     pub use crate::Animation2DPlugin;
 }


### PR DESCRIPTION
This allows controlling when animations are run, including pausing them completely. 

The use case is for example pausing animations when the game is paused:

```rust
app.configure_sets(
    Update,
    AnimationPlayer2DSystemSet,
        .run_if(not(in_state(IsPaused::Paused))),
);
```