### PR TITLE
Feature/issue 27 animation event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /Cargo.lock
+
+derive/target
+derive/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,7 @@ path = "examples/bevy_asset_loader.rs"
 [[example]]
 name = "pausing_animations"
 path = "examples/pausing_animations.rs"
+
+[[example]]
+name = "events"
+path = "examples/events.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["/assets"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bevy_trickfilm_derive = { path = "derive", version = "0.9.0-dev" }
 bevy = { version = "0.14", default-features = false, features=["bevy_asset", "bevy_sprite", "bevy_animation"]}
 serde = { version = "1", features = ["derive"] }
 ron = "0.8"

--- a/assets/gabe-idle-run-animation-events.trickfilm.ron
+++ b/assets/gabe-idle-run-animation-events.trickfilm.ron
@@ -1,25 +1,24 @@
 {
     "idle": (
         keyframes: KeyframesVec([0]),
-        /* optional */ keyframe_timestamps: Some([0.0]), /* Must be same size as keyframes, if provided */
+        /* optional */ keyframe_timestamps: [0.0], /* Must be same size as keyframes, if provided */
         duration: 0.1, /* Must be greater than max(keyframe_timestamps), if provided */
     ),
     "run": (
         keyframes: KeyframesRange((start: 1, end: 7)),
-        keyframe_timestamps: None,
         duration: 0.6, /* Must be greater than max(keyframe_timestamps), if provided */
         events: {
-            1: [
+            0: [
                 "events::SampleEvent": (
                     msg: "start",
                 )
             ],
-            4: [
+            3: [
                 "events::SampleEvent": (
                     msg: "middle",
                 )
             ],
-            7: [
+            5: [
                 "events::SampleEvent": (
                     msg: "end",
                 )

--- a/assets/gabe-idle-run-animation-events.trickfilm.ron
+++ b/assets/gabe-idle-run-animation-events.trickfilm.ron
@@ -1,0 +1,29 @@
+{
+    "idle": (
+        keyframes: KeyframesVec([0]),
+        /* optional */ keyframe_timestamps: Some([0.0]), /* Must be same size as keyframes, if provided */
+        duration: 0.1, /* Must be greater than max(keyframe_timestamps), if provided */
+    ),
+    "run": (
+        keyframes: KeyframesRange((start: 1, end: 7)),
+        keyframe_timestamps: None,
+        duration: 0.6, /* Must be greater than max(keyframe_timestamps), if provided */
+        events: {
+            1: [
+                "events::SampleEvent": (
+                    msg: "start",
+                )
+            ],
+            4: [
+                "events::SampleEvent": (
+                    msg: "middle",
+                )
+            ],
+            7: [
+                "events::SampleEvent": (
+                    msg: "end",
+                )
+            ],
+        }
+    ),
+}

--- a/assets/gabe-idle-run-animation-events.trickfilm.ron
+++ b/assets/gabe-idle-run-animation-events.trickfilm.ron
@@ -8,21 +8,21 @@
         keyframes: KeyframesRange((start: 1, end: 7)),
         duration: 0.6, /* Must be greater than max(keyframe_timestamps), if provided */
         events: {
-            0: [
+            0: {
                 "events::SampleEvent": (
                     msg: "start",
                 )
-            ],
-            3: [
+            },
+            3: {
                 "events::SampleEvent": (
                     msg: "middle",
                 )
-            ],
-            5: [
+            },
+            5: {
                 "events::SampleEvent": (
                     msg: "end",
                 )
-            ],
+            },
         }
     ),
 }

--- a/assets/gabe-idle-run-animation.trickfilm.ron
+++ b/assets/gabe-idle-run-animation.trickfilm.ron
@@ -1,12 +1,11 @@
 {
     "idle": (
         keyframes: KeyframesVec([0]),
-        /* optional */ keyframe_timestamps: Some([0.0]), /* Must be same size as keyframes, if provided */
+        /* optional */ keyframe_timestamps: [0.0], /* Must be same size as keyframes, if provided */
         duration: 0.1, /* Must be greater than max(keyframe_timestamps), if provided */
     ),
     "run": (
         keyframes: KeyframesRange((start: 1, end: 7)),
-        keyframe_timestamps: None,
         duration: 0.6, /* Must be greater than max(keyframe_timestamps), if provided */
     ),
 }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+authors = ["KirmesBude <kirmesbude@gmail.com>"]
+name = "bevy_trickfilm_derive"
+version = "0.9.0-dev"
+edition = "2021"
+description = "Derive implementations for bevy_trickfilm"
+repository = "https://github.com/KirmesBude/bevy_trickfilm"
+license = "MIT OR Apache-2.0"
+keywords = ["gamedev", "bevy", "animation", "spritesheet", "assets"]
+categories = ["game-development"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+bevy_macro_utils = "0.14.2"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -20,30 +20,29 @@ pub fn derive_animation_event(input: TokenStream) -> TokenStream {
 
     let mut target = None;
 
-    match ast.data {
-        // Only process structs
-        syn::Data::Struct(ref data_struct) => {
-            // Check the kind of fields the struct contains
-            // Structs with named fields
-            if let syn::Fields::Named(ref fields_named) = data_struct.fields {
-                // Iterate over the fields
-                for field in fields_named.named.iter() {
-                    // Get attributes #[..] on each field
-                    for attr in field.attrs.iter() {
-                        // Parse the attribute
-                        if let syn::Meta::Path(ref path) = attr.meta {
-                            if let Some(ident) = path.get_ident() {
-                                if ident == "target" {
-                                    target = Some(field.ident.clone());
-                                }
+    // Only process structs
+    if let syn::Data::Struct(ref data_struct) = ast.data {
+        // Check the kind of fields the struct contains
+        // Structs with named fields
+        if let syn::Fields::Named(ref fields_named) = data_struct.fields {
+            // Iterate over the fields
+            for field in fields_named.named.iter() {
+                // Get attributes #[..] on each field
+                for attr in field.attrs.iter() {
+                    // Parse the attribute
+                    if let syn::Meta::Path(ref path) = attr.meta {
+                        if let Some(ident) = path.get_ident() {
+                            if ident == "target" {
+                                if target.is_some() {
+                                    panic!("Multiple `#[target] attributes. Only a single target is supported.")
+                                };
+                                target = Some(field.ident.clone());
                             }
                         }
                     }
                 }
             }
         }
-        // Panic when we don't have a struct
-        _ => panic!("Must be a struct"),
     }
 
     match target {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,0 +1,28 @@
+/// Derive macros for bevy_trickfilm
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, parse_quote, DeriveInput};
+
+extern crate proc_macro;
+
+/// Derive macro for AnimationEvent
+#[proc_macro_derive(AnimationEvent)]
+pub fn derive_animation_event(input: TokenStream) -> TokenStream {
+    let mut ast = parse_macro_input!(input as DeriveInput);
+
+    ast.generics
+        .make_where_clause()
+        .predicates
+        .push(parse_quote! { Self: bevy::ecs::event::Event + bevy::reflect::GetTypeRegistration + bevy::reflect::FromReflect });
+
+    let struct_name = &ast.ident;
+    let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
+
+    TokenStream::from(quote! {
+        impl #impl_generics bevy_trickfilm::animation::event::AnimationEvent for #struct_name #type_generics #where_clause {
+            fn set_entity(&mut self, entity: Entity) {
+                self.entity = entity;
+            }
+        }
+    })
+}

--- a/docs/FileFormatSpecification.md
+++ b/docs/FileFormatSpecification.md
@@ -3,20 +3,20 @@
 ## Trickfilm
 | Type                           | Necessity | Description |
 |--------------------------------|-----------|-------------|
-| Map of String,[TrickfilmEntry] | mandatory | All named animation clips of this animation clip set. Can not be empty. If multiple animation clips with the same name are defined, only the last entry is considered. |
+| Map of String,[AnimationClip2D] | mandatory | All named animation clips of this animation clip set. Can not be empty. If multiple animation clips with the same name are defined, only the last entry is considered. |
 
-## TrickfilmEntry
+## AnimationClip2D
 | Field               | Type                      | Necessity | Description |
 |---------------------|---------------------------|-----------|-------------|
-| keyframes           | [TrickfilmEntryKeyframes] | mandatory | Keyframes of this animation clip corresponding to the indices in the texture atlas. |
+| keyframes           | [Keyframes] | mandatory | Keyframes of this animation clip corresponding to the indices in the texture atlas. |
 | keyframe_timestamps | Option of Vector of f32   | optional  | Timestamp of the corresponding keyframe of this animation clip in seconds. Default value is None, but will be calculated so all keyframes are equally distributed along the entire duration. |
 | duration            | f32                       | mandatory | Duration of this animation clip in seconds. Must be greater than the maximum keyframe timestamp. |
 
-## TrickfilmEntryKeyframes
+## Keyframes
 | Variant        | Description |
 |----------------|-------------|
 | KeyframesVec   | Vec of usize corresponding to individual keyframes. |
-| KeyframesRange | Range of ussize corresponding to a range of keyframes. |
+| KeyframesRange | Range of usize corresponding to a range of keyframes. |
 
-[TrickfilmEntry]: #trickfilmentry
-[TrickfilmEntryKeyframes]: #trickfilmentrykeyframes
+[AnimationClip2D]: #animationclip2d
+[Keyframes]: #keyframes

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,11 +14,13 @@ Example                        | Description |
 [Sprite sheet animation]       | Shows of how to use `bevy_trickfilm` with a sprite sheet. |
 [Using bevy_titan]             | Simple example with [bevy_titan]. |
 [Using bevy_asset_loader]      | Simple example with [bevy_asset_loader]. |
-[Pausing animations]           | Simple example to show how to globally pause all animtions. |
+[Pausing animations]           | Simple example to show how to globally pause all animations. |
+[Animation Events]             | Simple example to show how to use animation events. |
 
 [Sprite sheet animation]: ../examples/sprite_sheet_animation.rs
 [Using bevy_titan]: ../examples/sprite_sheet_animation_titan.rs
 [Using bevy_asset_loader]: ../examples/bevy_asset_loader.rs
 [Pausing animations]: ../examples/pausing_animations.rs
+[Animation Events]: ../examples/events.rs
 [bevy_asset_loader]: https://crates.io/crates/bevy_asset_loader
 [bevy_titan]: https://crates.io/crates/bevy_titan

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -25,9 +25,22 @@ fn main() {
         .run();
 }
 
+fn lol() -> Entity {
+    Entity::PLACEHOLDER
+}
+
 #[derive(Debug, Clone, Event, Reflect)]
 struct SampleEvent {
+    #[reflect(ignore)]
+    #[reflect(default = "lol")]
+    entity: Entity,
     msg: String,
+}
+
+impl AnimationEvent for SampleEvent {
+    fn set_entity(&mut self, entity: Entity) {
+        self.entity = entity;
+    }
 }
 
 #[derive(Resource)]
@@ -55,12 +68,15 @@ fn setup(
     ));
 
     let start = SampleEvent {
+        entity: lol(),
         msg: String::from("start"),
     };
     let middle = SampleEvent {
+        entity: lol(),
         msg: String::from("middle"),
     };
     let end = SampleEvent {
+        entity: lol(),
         msg: String::from("end"),
     };
 
@@ -146,6 +162,6 @@ fn update_frame_text(
 
 fn print_event(mut event_reader: EventReader<SampleEvent>) {
     for event in event_reader.read() {
-        println!("{}", event.msg);
+        println!("{:?}", event);
     }
 }

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -15,9 +15,8 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
         .add_plugins(Animation2DPlugin)
-        .add_event::<SampleEvent>()
+        // add_animation_event will add the event to the app, register the type and setup trickfilm internal resources and systems
         .add_animation_event::<SampleEvent>()
-        .register_type::<SampleEvent>()
         .add_systems(Startup, setup)
         .add_systems(
             Update,
@@ -26,9 +25,11 @@ fn main() {
         .run();
 }
 
+// This Event needs to implement AnimationEvent
 #[derive(Debug, Clone, Event, Reflect, AnimationEvent)]
 struct SampleEvent {
     #[reflect(skip_serializing)]
+    // This is necessary, because EventTarget is not given via the trickfilm file, but at runtime via the AnimationEvent trait
     #[target]
     target: EventTarget,
     msg: String,
@@ -122,6 +123,7 @@ fn update_frame_text(
     text.sections[0].value = format!("current frame: {}", animation_player.frame());
 }
 
+// You can easily react on your custom event just like a normal bevy event
 fn print_event(mut event_reader: EventReader<SampleEvent>) {
     for event in event_reader.read() {
         println!("{:?}", event);

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -9,6 +9,7 @@ mod animation_helper;
 use animation_helper::keyboard_animation_control_helper;
 use bevy::prelude::*;
 use bevy_trickfilm::prelude::*;
+use bevy_trickfilm_derive::AnimationEvent;
 
 fn main() {
     App::new()
@@ -25,18 +26,12 @@ fn main() {
         .run();
 }
 
-#[derive(Debug, Clone, Event, Reflect)]
+#[derive(Debug, Clone, Event, Reflect, AnimationEvent)]
 struct SampleEvent {
     #[reflect(skip_serializing)]
     #[reflect(default = "default_entity")]
     entity: Entity,
     msg: String,
-}
-
-impl AnimationEvent for SampleEvent {
-    fn set_entity(&mut self, entity: Entity) {
-        self.entity = entity;
-    }
 }
 
 #[derive(Resource)]

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -7,7 +7,7 @@
 mod animation_helper;
 
 use animation_helper::keyboard_animation_control_helper;
-use bevy::{prelude::*, utils::HashMap};
+use bevy::prelude::*;
 use bevy_trickfilm::prelude::*;
 
 fn main() {
@@ -47,7 +47,6 @@ struct FrameText;
 
 fn setup(
     mut commands: Commands,
-    mut clips: ResMut<Assets<AnimationClip2D>>,
     asset_server: Res<AssetServer>,
     mut texture_atlas_layouts: ResMut<Assets<TextureAtlasLayout>>,
 ) {
@@ -62,47 +61,6 @@ fn setup(
             },
         ),
     ));
-
-    let start = SampleEvent {
-        entity: default_entity(),
-        msg: String::from("start"),
-    };
-    let middle = SampleEvent {
-        entity: default_entity(),
-        msg: String::from("middle"),
-    };
-    let end = SampleEvent {
-        entity: default_entity(),
-        msg: String::from("end"),
-    };
-
-    // animation events
-    let mut events = HashMap::new();
-    events.insert(0, vec![start.as_reflect().clone_value()]);
-    events.insert(3, vec![middle.as_reflect().clone_value()]);
-    events.insert(5, vec![end.as_reflect().clone_value()]);
-
-    // Load all animations
-    let animations = vec![
-        clips.add(
-            AnimationClip2D::new(
-                Some(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5]),
-                bevy_trickfilm::asset::Keyframes::KeyframesVec(vec![1, 2, 3, 4, 5, 6]),
-                0.6,
-                Some(events),
-            )
-            .unwrap(),
-        ),
-        clips.add(
-            AnimationClip2D::new(
-                Some(vec![0.0]),
-                bevy_trickfilm::asset::Keyframes::KeyframesVec(vec![0]),
-                0.1,
-                None,
-            )
-            .unwrap(),
-        ),
-    ];
 
     let animations = vec![
         asset_server.load("gabe-idle-run-animation-events.trickfilm.ron#run"),

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -7,7 +7,7 @@
 mod animation_helper;
 
 use animation_helper::keyboard_animation_control_helper;
-use bevy::prelude::*;
+use bevy::{prelude::*, utils::HashMap};
 use bevy_trickfilm::prelude::*;
 
 fn main() {
@@ -38,6 +38,7 @@ struct FrameText;
 
 fn setup(
     mut commands: Commands,
+    mut clips: ResMut<Assets<AnimationClip2D>>,
     asset_server: Res<AssetServer>,
     mut texture_atlas_layouts: ResMut<Assets<TextureAtlasLayout>>,
 ) {
@@ -53,10 +54,34 @@ fn setup(
         ),
     ));
 
+    let start = SampleEvent {
+        msg: String::from("start"),
+    };
+    let middle = SampleEvent {
+        msg: String::from("middle"),
+    };
+    let end = SampleEvent {
+        msg: String::from("end"),
+    };
+
+    // animation events
+    let mut events = HashMap::new();
+    events.insert(1, vec![start.as_reflect().clone_value()]);
+    events.insert(3, vec![middle.as_reflect().clone_value()]);
+    events.insert(6, vec![end.as_reflect().clone_value()]);
+
     // Load all animations
     let animations = vec![
-        asset_server.load("gabe-idle-run-animation-events.trickfilm.ron#run"),
-        asset_server.load("gabe-idle-run-animation-events.trickfilm.ron#idle"),
+        clips.add(
+            AnimationClip2D::new(
+                vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
+                vec![1, 2, 3, 4, 5, 6],
+                0.6,
+                events,
+            )
+            .unwrap(),
+        ),
+        clips.add(AnimationClip2D::new(vec![0.0], vec![0], 0.1, HashMap::new()).unwrap()),
     ];
 
     let atlas_texture = asset_server.load("gabe-idle-run.png");

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -8,7 +8,7 @@ mod animation_helper;
 
 use animation_helper::keyboard_animation_control_helper;
 use bevy::prelude::*;
-use bevy_trickfilm::prelude::*;
+use bevy_trickfilm::{animation::event::EventTarget, prelude::*};
 use bevy_trickfilm_derive::AnimationEvent;
 
 fn main() {
@@ -29,8 +29,8 @@ fn main() {
 #[derive(Debug, Clone, Event, Reflect, AnimationEvent)]
 struct SampleEvent {
     #[reflect(skip_serializing)]
-    #[reflect(default = "default_entity")]
-    entity: Entity,
+    #[target]
+    target: EventTarget,
     msg: String,
 }
 

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -82,9 +82,9 @@ fn setup(
 
     // animation events
     let mut events = HashMap::new();
-    events.insert(1, vec![start.as_reflect().clone_value()]);
+    events.insert(0, vec![start.as_reflect().clone_value()]);
     events.insert(3, vec![middle.as_reflect().clone_value()]);
-    events.insert(6, vec![end.as_reflect().clone_value()]);
+    events.insert(5, vec![end.as_reflect().clone_value()]);
 
     // Load all animations
     let animations = vec![

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -104,6 +104,11 @@ fn setup(
         ),
     ];
 
+    let animations = vec![
+        asset_server.load("gabe-idle-run-animation-events.trickfilm.ron#run"),
+        asset_server.load("gabe-idle-run-animation-events.trickfilm.ron#idle"),
+    ];
+
     let atlas_texture = asset_server.load("gabe-idle-run.png");
     let texture_atlas_layout = TextureAtlasLayout::from_grid(UVec2::new(24, 24), 7, 1, None, None);
     let texture_atlas = TextureAtlas {

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -25,14 +25,10 @@ fn main() {
         .run();
 }
 
-fn lol() -> Entity {
-    Entity::PLACEHOLDER
-}
-
 #[derive(Debug, Clone, Event, Reflect)]
 struct SampleEvent {
-    #[reflect(ignore)]
-    #[reflect(default = "lol")]
+    #[reflect(skip_serializing)]
+    #[reflect(default = "default_entity")]
     entity: Entity,
     msg: String,
 }
@@ -68,15 +64,15 @@ fn setup(
     ));
 
     let start = SampleEvent {
-        entity: lol(),
+        entity: default_entity(),
         msg: String::from("start"),
     };
     let middle = SampleEvent {
-        entity: lol(),
+        entity: default_entity(),
         msg: String::from("middle"),
     };
     let end = SampleEvent {
-        entity: lol(),
+        entity: default_entity(),
         msg: String::from("end"),
     };
 

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -86,19 +86,19 @@ fn setup(
     let animations = vec![
         clips.add(
             AnimationClip2D::new(
-                vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
+                Some(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5]),
                 bevy_trickfilm::asset::Keyframes::KeyframesVec(vec![1, 2, 3, 4, 5, 6]),
                 0.6,
-                events,
+                Some(events),
             )
             .unwrap(),
         ),
         clips.add(
             AnimationClip2D::new(
-                vec![0.0],
+                Some(vec![0.0]),
                 bevy_trickfilm::asset::Keyframes::KeyframesVec(vec![0]),
                 0.1,
-                HashMap::new(),
+                None,
             )
             .unwrap(),
         ),

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -87,13 +87,21 @@ fn setup(
         clips.add(
             AnimationClip2D::new(
                 vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
-                vec![1, 2, 3, 4, 5, 6],
+                bevy_trickfilm::asset::Keyframes::KeyframesVec(vec![1, 2, 3, 4, 5, 6]),
                 0.6,
                 events,
             )
             .unwrap(),
         ),
-        clips.add(AnimationClip2D::new(vec![0.0], vec![0], 0.1, HashMap::new()).unwrap()),
+        clips.add(
+            AnimationClip2D::new(
+                vec![0.0],
+                bevy_trickfilm::asset::Keyframes::KeyframesVec(vec![0]),
+                0.1,
+                HashMap::new(),
+            )
+            .unwrap(),
+        ),
     ];
 
     let atlas_texture = asset_server.load("gabe-idle-run.png");

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -14,9 +14,20 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
         .add_plugins(Animation2DPlugin)
+        .add_event::<SampleEvent>()
+        .add_animation_event::<SampleEvent>()
+        .register_type::<SampleEvent>()
         .add_systems(Startup, setup)
-        .add_systems(Update, (keyboard_animation_control, update_frame_text))
+        .add_systems(
+            Update,
+            (keyboard_animation_control, update_frame_text, print_event),
+        )
         .run();
+}
+
+#[derive(Debug, Clone, Event, Reflect)]
+struct SampleEvent {
+    msg: String,
 }
 
 #[derive(Resource)]
@@ -44,8 +55,8 @@ fn setup(
 
     // Load all animations
     let animations = vec![
-        asset_server.load("gabe-idle-run-animation.trickfilm.ron#run"),
-        asset_server.load("gabe-idle-run-animation.trickfilm.ron#idle"),
+        asset_server.load("gabe-idle-run-animation-events.trickfilm.ron#run"),
+        asset_server.load("gabe-idle-run-animation-events.trickfilm.ron#idle"),
     ];
 
     let atlas_texture = asset_server.load("gabe-idle-run.png");
@@ -106,4 +117,10 @@ fn update_frame_text(
     };
 
     text.sections[0].value = format!("current frame: {}", animation_player.frame());
+}
+
+fn print_event(mut event_reader: EventReader<SampleEvent>) {
+    for event in event_reader.read() {
+        println!("{}", event.msg);
+    }
 }

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -1,0 +1,109 @@
+//! Adapted from https://github.com/bevyengine/bevy/blob/v0.9.1/examples/2d/sprite_sheet.rs
+//! and https://github.com/bevyengine/bevy/blob/v0.9.1/examples/animation/animated_fox.rs
+//! Renders an animated sprite by loading all animation frames from multiple sprites
+//! and changing the displayed image periodically.
+
+#[path = "helpers/animation_controller.rs"]
+mod animation_helper;
+
+use animation_helper::keyboard_animation_control_helper;
+use bevy::prelude::*;
+use bevy_trickfilm::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
+        .add_plugins(Animation2DPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, (keyboard_animation_control, update_frame_text))
+        .run();
+}
+
+#[derive(Resource)]
+struct Animations(Vec<Handle<AnimationClip2D>>);
+
+#[derive(Component)]
+struct FrameText;
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut texture_atlas_layouts: ResMut<Assets<TextureAtlasLayout>>,
+) {
+    commands.spawn((
+        FrameText,
+        TextBundle::from_section(
+            "current frame: 0",
+            TextStyle {
+                font_size: 24.0,
+                color: Color::WHITE,
+                ..default()
+            },
+        ),
+    ));
+
+    // Load all animations
+    let animations = vec![
+        asset_server.load("gabe-idle-run-animation.trickfilm.ron#run"),
+        asset_server.load("gabe-idle-run-animation.trickfilm.ron#idle"),
+    ];
+
+    let atlas_texture = asset_server.load("gabe-idle-run.png");
+    let texture_atlas_layout = TextureAtlasLayout::from_grid(UVec2::new(24, 24), 7, 1, None, None);
+    let texture_atlas = TextureAtlas {
+        layout: texture_atlas_layouts.add(texture_atlas_layout),
+        ..Default::default()
+    };
+
+    // Camera
+    commands.spawn(Camera2dBundle::default());
+
+    // Prepare AnimationPlayer
+    let mut animation_player = AnimationPlayer2D::default();
+    animation_player.play(animations[0].clone_weak()).repeat();
+
+    // Insert a resource with the current animation information
+    commands.insert_resource(Animations(animations));
+
+    // SpriteSheet entity
+    commands
+        .spawn(SpriteBundle {
+            transform: Transform::from_scale(Vec3::splat(6.0)),
+            texture: atlas_texture,
+            ..Default::default()
+        })
+        .insert(texture_atlas)
+        .insert(animation_player);
+}
+
+fn keyboard_animation_control(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mut animation_player: Query<&mut AnimationPlayer2D>,
+    animations: Res<Animations>,
+    mut current_animation: Local<usize>,
+    mut instructions_printed: Local<bool>,
+) {
+    if let Ok(mut player) = animation_player.get_single_mut() {
+        keyboard_animation_control_helper(
+            &keyboard_input,
+            &mut player,
+            &animations.0,
+            &mut current_animation,
+            &mut instructions_printed,
+        );
+    }
+}
+
+fn update_frame_text(
+    mut q_frame_text: Query<&mut Text, With<FrameText>>,
+    q_animation_player: Query<&AnimationPlayer2D>,
+) {
+    let Ok(mut text) = q_frame_text.get_single_mut() else {
+        return;
+    };
+    let Ok(animation_player) = q_animation_player.get_single() else {
+        return;
+    };
+
+    text.sections[0].value = format!("current frame: {}", animation_player.frame());
+}

--- a/src/animation/animation_spritesheet.rs
+++ b/src/animation/animation_spritesheet.rs
@@ -71,6 +71,6 @@ fn apply_animation_player_spritesheet(
 
         animation.frame = index;
         let keyframes = animation_clip.keyframes();
-        *texture_atlas_index = keyframes.get(index).unwrap();
+        *texture_atlas_index = keyframes.get(index).expect("index is constructed from keyframe_timestamps which ensures that the operation always succeeds.");
     }
 }

--- a/src/animation/animation_spritesheet.rs
+++ b/src/animation/animation_spritesheet.rs
@@ -71,6 +71,6 @@ fn apply_animation_player_spritesheet(
 
         animation.frame = index;
         let keyframes = animation_clip.keyframes();
-        *texture_atlas_index = keyframes[index]
+        *texture_atlas_index = keyframes.get(index).unwrap();
     }
 }

--- a/src/animation/animation_spritesheet.rs
+++ b/src/animation/animation_spritesheet.rs
@@ -69,7 +69,8 @@ fn apply_animation_player_spritesheet(
             Err(i) => i - 1,
         };
 
-        animation.frame = index;
+        animation.last_frame = animation.frame;
+        animation.frame = Some(index);
         let keyframes = animation_clip.keyframes();
         *texture_atlas_index = keyframes.get(index).expect("index is constructed from keyframe_timestamps which ensures that the operation always succeeds.");
     }

--- a/src/animation/event.rs
+++ b/src/animation/event.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, reflect::GetTypeRegistration, utils::HashMap};
 
 use crate::asset::AnimationClip2D;
 
@@ -8,7 +8,7 @@ use super::{
 };
 
 /// AnimationEvents are triggered by the animation system if registered as such with the App.
-pub trait AnimationEvent: Event + FromReflect {
+pub trait AnimationEvent: Event + GetTypeRegistration + FromReflect {
     /// Implement this to be able to set the entity for a targeted event.
     /// Default implementation is a No-Op.
     fn set_entity(&mut self, entity: Entity) {
@@ -21,46 +21,57 @@ pub fn default_entity() -> Entity {
     Entity::PLACEHOLDER
 }
 
-// Define generic trigger and event systems
-pub fn send_animation_event<T: AnimationEvent>(
+fn collect_events<T: AnimationEvent>(
+    animation_players: Query<(Entity, &AnimationPlayer2D)>,
+    animation_clips: &Assets<AnimationClip2D>,
+) -> HashMap<Entity, Vec<T>> {
+    animation_players
+        .iter()
+        .map(|(entity, animation_player)| {
+            let mut events = Vec::with_capacity(0);
+            if let Some(animation_clip) = animation_clips.get(animation_player.animation_clip()) {
+                // TODO: I need a better way to detect frame changes here
+                // Get all events for this frame transition, if any
+                if let Some(reflected_events) =
+                    animation_clip.events().get(&animation_player.frame())
+                {
+                    events.reserve(reflected_events.len());
+                    for reflected_event in reflected_events {
+                        // TODO: Is this the most efficient way?
+                        if let Some(mut event) = T::from_reflect(reflected_event.as_reflect()) {
+                            event.set_entity(entity);
+                            events.push(event);
+                        }
+                    }
+                }
+            }
+            (entity, events)
+        })
+        .collect()
+}
+
+fn send_animation_event<T: AnimationEvent>(
     mut event_writer: EventWriter<T>,
     animation_players: Query<(Entity, &AnimationPlayer2D)>,
     animation_clips: Res<Assets<AnimationClip2D>>,
 ) {
-    for (entity, animation_player) in &animation_players {
-        if let Some(animation_clip) = animation_clips.get(animation_player.animation_clip()) {
-            if let Some(reflected_events) = animation_clip.events().get(&animation_player.frame()) {
-                for reflected_event in reflected_events {
-                    // TODO: Patch in entity somehow
-                    if let Some(mut event) = T::from_reflect(reflected_event.as_reflect()) {
-                        // TODO: batch
-                        event.set_entity(entity);
-                        event_writer.send(event);
-                    }
-                }
-            }
-        }
+    let entity_event_map = collect_events::<T>(animation_players, &animation_clips);
+
+    for (_, events) in entity_event_map {
+        event_writer.send_batch(events);
     }
 }
 
-// TODO: generalize the query stuff
-pub fn trigger_animation_event<T: AnimationEvent>(
+fn trigger_animation_event<T: AnimationEvent>(
     mut commands: Commands,
     animation_players: Query<(Entity, &AnimationPlayer2D)>,
     animation_clips: Res<Assets<AnimationClip2D>>,
 ) {
-    for (entity, animation_player) in &animation_players {
-        if let Some(animation_clip) = animation_clips.get(animation_player.animation_clip()) {
-            if let Some(reflected_events) = animation_clip.events().get(&animation_player.frame()) {
-                for reflected_event in reflected_events {
-                    // TODO: Patch in entity somehow
-                    if let Some(mut event) = T::from_reflect(reflected_event.as_reflect()) {
-                        // TODO: batch
-                        event.set_entity(entity);
-                        commands.trigger(event);
-                    }
-                }
-            }
+    let entity_event_map = collect_events::<T>(animation_players, &animation_clips);
+
+    for (entity, events) in entity_event_map {
+        for event in events {
+            commands.trigger_targets(event, entity);
         }
     }
 }
@@ -76,6 +87,7 @@ pub trait AnimationEventAppExtension {
 
 impl AnimationEventAppExtension for App {
     fn add_animation_event<T: AnimationEvent>(&mut self) -> &mut Self {
+        self.add_event::<T>().register_type::<T>();
         self.add_systems(
             PostUpdate,
             send_animation_event::<T>
@@ -85,6 +97,7 @@ impl AnimationEventAppExtension for App {
     }
 
     fn add_animation_trigger<T: AnimationEvent>(&mut self) -> &mut Self {
+        self.register_type::<T>(); // add_event is not necessary for observers
         self.add_systems(
             PostUpdate,
             trigger_animation_event::<T>

--- a/src/animation/event.rs
+++ b/src/animation/event.rs
@@ -7,8 +7,12 @@ use super::{
     AnimationPlayer2DSystemSet,
 };
 
+/// AnimationEvents are triggered by the animation system if registered as such with the App.
 pub trait AnimationEvent: Event + FromReflect {
+    /// Implement this to be able to set the entity for a targeted event.
+    /// Default implementation is a No-Op.
     fn set_entity(&mut self, entity: Entity) {
+        let _ = entity;
         /* Default implementation is empty for non-targeted events */
     }
 }
@@ -21,7 +25,7 @@ pub fn send_animation_event<T: AnimationEvent>(
 ) {
     for (entity, animation_player) in &animation_players {
         if let Some(animation_clip) = animation_clips.get(animation_player.animation_clip()) {
-            if let Some(reflected_events) = animation_clip.events.get(&animation_player.frame()) {
+            if let Some(reflected_events) = animation_clip.events().get(&animation_player.frame()) {
                 for reflected_event in reflected_events {
                     // TODO: Patch in entity somehow
                     if let Some(mut event) = T::from_reflect(reflected_event.as_reflect()) {
@@ -43,7 +47,7 @@ pub fn trigger_animation_event<T: AnimationEvent>(
 ) {
     for (entity, animation_player) in &animation_players {
         if let Some(animation_clip) = animation_clips.get(animation_player.animation_clip()) {
-            if let Some(reflected_events) = animation_clip.events.get(&animation_player.frame()) {
+            if let Some(reflected_events) = animation_clip.events().get(&animation_player.frame()) {
                 for reflected_event in reflected_events {
                     // TODO: Patch in entity somehow
                     if let Some(mut event) = T::from_reflect(reflected_event.as_reflect()) {
@@ -57,11 +61,12 @@ pub fn trigger_animation_event<T: AnimationEvent>(
     }
 }
 
-// Add extension to app to add animation_events/animation_triggers, which will schedule these systems for the specific type
-
+/// App extension trait to add animation_events/animation_triggers, which will schedule these sending/triggering systems for the specific type
 pub trait AnimationEventAppExtension {
+    /// Add event as buffered event.
     fn add_animation_event<T: AnimationEvent>(&mut self) -> &mut Self;
 
+    /// Add event as observer.
     fn add_animation_trigger<T: AnimationEvent>(&mut self) -> &mut Self;
 }
 

--- a/src/animation/event.rs
+++ b/src/animation/event.rs
@@ -47,6 +47,7 @@ fn update_animation_event_cache<T: FromReflect>(
     animation_clips: Res<Assets<AnimationClip2D>>,
 ) {
     for asset_event in asset_events.read() {
+        println!("{:?}", asset_event);
         match asset_event {
             AssetEvent::Added { id }
             | AssetEvent::Modified { id }

--- a/src/animation/event.rs
+++ b/src/animation/event.rs
@@ -84,13 +84,13 @@ fn collect_events<T: AnimationEvent>(
         .map(|(entity, animation_player)| {
             let mut events: Vec<T> = Vec::with_capacity(0);
             if let Some(event_map) = cache.0.get(&animation_player.animation_clip().id()) {
-                // TODO: I need a better way to detect frame changes here
-                // Get all events for this frame transition, if any
-                if let Some(animation_events) = event_map.get(&animation_player.frame()) {
-                    events = animation_events.clone();
-                    events
-                        .iter_mut()
-                        .for_each(|event| event.set_target(EventTarget(entity)));
+                if animation_player.animation.last_frame != animation_player.animation.frame {
+                    if let Some(animation_events) = event_map.get(&animation_player.frame()) {
+                        events = animation_events.clone();
+                        events
+                            .iter_mut()
+                            .for_each(|event| event.set_target(EventTarget(entity)));
+                    }
                 }
             }
             (entity, events)

--- a/src/animation/event.rs
+++ b/src/animation/event.rs
@@ -1,0 +1,75 @@
+use bevy::prelude::*;
+
+use crate::asset::AnimationClip2D;
+
+use super::{
+    animation_spritesheet::animation_player_spritesheet, AnimationPlayer2D,
+    AnimationPlayer2DSystemSet,
+};
+
+// Trait
+pub trait AnimationEvent: Event {
+    fn from_reflect(entity: Entity, reflect: &dyn Reflect) -> Self;
+}
+
+// Define generic trigger and event systems
+pub fn send_animation_event<T: Event + AnimationEvent>(
+    mut event_writer: EventWriter<T>,
+    animation_players: Query<(Entity, &AnimationPlayer2D)>,
+    animation_clips: Res<Assets<AnimationClip2D>>,
+) {
+    for (entity, animation_player) in &animation_players {
+        if let Some(animation_clip) = animation_clips.get(animation_player.animation_clip()) {
+            // TODO: Get "Reflect" data from event field on AnimationClip2D
+            let reflect = ().as_reflect();
+
+            // TODO: batch
+            event_writer.send(T::from_reflect(entity, reflect));
+        }
+    }
+}
+
+// TODO: generalize the query stuff
+pub fn trigger_animation_event<T: Event + AnimationEvent>(
+    mut commands: Commands,
+    animation_players: Query<(Entity, &AnimationPlayer2D)>,
+    animation_clips: Res<Assets<AnimationClip2D>>,
+) {
+    for (entity, animation_player) in &animation_players {
+        if let Some(animation_clip) = animation_clips.get(animation_player.animation_clip()) {
+            // TODO: Get "Reflect" data from event field on AnimationClip2D
+            let reflect = ().as_reflect();
+
+            // TODO: batch
+            commands.trigger(T::from_reflect(entity, reflect));
+        }
+    }
+}
+
+// Add extension to app to add animation_events/animation_triggers, which will schedule these systems for the specific type
+
+pub trait AnimationEventAppExtension {
+    fn add_animation_event<T: Event + AnimationEvent>(&mut self) -> &mut Self;
+
+    fn add_animation_trigger<T: Event + AnimationEvent>(&mut self) -> &mut Self;
+}
+
+impl AnimationEventAppExtension for App {
+    fn add_animation_event<T: Event + AnimationEvent>(&mut self) -> &mut Self {
+        self.add_systems(
+            PostUpdate,
+            send_animation_event::<T>
+                .in_set(AnimationPlayer2DSystemSet)
+                .after(animation_player_spritesheet),
+        )
+    }
+
+    fn add_animation_trigger<T: Event + AnimationEvent>(&mut self) -> &mut Self {
+        self.add_systems(
+            PostUpdate,
+            trigger_animation_event::<T>
+                .in_set(AnimationPlayer2DSystemSet)
+                .after(animation_player_spritesheet),
+        )
+    }
+}

--- a/src/animation/event.rs
+++ b/src/animation/event.rs
@@ -17,6 +17,10 @@ pub trait AnimationEvent: Event + FromReflect {
     }
 }
 
+pub fn default_entity() -> Entity {
+    Entity::PLACEHOLDER
+}
+
 // Define generic trigger and event systems
 pub fn send_animation_event<T: AnimationEvent>(
     mut event_writer: EventWriter<T>,

--- a/src/animation/event.rs
+++ b/src/animation/event.rs
@@ -1,4 +1,4 @@
-//! This module animition event.
+//! This module implements everything necessary to support arbitrary events.
 //!
 
 use bevy::{prelude::*, reflect::GetTypeRegistration, utils::HashMap};
@@ -10,7 +10,7 @@ use super::{
     AnimationPlayer2DSystemSet,
 };
 
-/// AnimationEvents are triggered by the animation system if registered as such with the App.
+/// AnimationEvents are triggered by the animation system if registered as such with the App
 pub trait AnimationEvent: Event + GetTypeRegistration + FromReflect + Clone {
     /// Implement this to be able to set the entity for a targeted event.
     /// Default implementation is a No-Op.
@@ -21,7 +21,7 @@ pub trait AnimationEvent: Event + GetTypeRegistration + FromReflect + Clone {
 }
 
 /// Wrapper around entity to be used for EventTargets
-#[derive(Debug, Clone, Copy, Deref, Reflect)] //TODO: register type
+#[derive(Debug, Clone, Copy, Deref, Reflect)]
 pub struct EventTarget(pub Entity);
 
 impl Default for EventTarget {
@@ -40,7 +40,7 @@ impl<T> Default for AnimationEventCache<T> {
 }
 
 // This updates a cache resource for each Event added to the app
-// That way when processing animation for event sending, we already have a vector of T instead of Box<dyn Reflect>, so we only iterate through the events that are actually relecant (can be from_reflected to T)
+// That way when processing animation for event sending, we already have a vector of T instead of Box<dyn Reflect>, so we only iterate through the events that are actually relevant (can be from_reflected to T)
 fn update_animation_event_cache<T: FromReflect>(
     mut cache: ResMut<AnimationEventCache<T>>,
     mut asset_events: EventReader<AssetEvent<AnimationClip2D>>,
@@ -80,6 +80,8 @@ fn update_animation_event_cache<T: FromReflect>(
     }
 }
 
+// Collects events in a vector per entity for batching purposes
+// Also calls AnimationEvent's set_target
 fn collect_events<T: AnimationEvent>(
     animation_players: Query<(Entity, &AnimationPlayer2D)>,
     cache: &AnimationEventCache<T>,
@@ -103,6 +105,7 @@ fn collect_events<T: AnimationEvent>(
         .collect()
 }
 
+// Batch send events
 fn send_animation_event<T: AnimationEvent>(
     mut event_writer: EventWriter<T>,
     animation_players: Query<(Entity, &AnimationPlayer2D)>,
@@ -115,6 +118,7 @@ fn send_animation_event<T: AnimationEvent>(
     }
 }
 
+// Trigger events
 fn trigger_animation_event<T: AnimationEvent>(
     mut commands: Commands,
     animation_players: Query<(Entity, &AnimationPlayer2D)>,

--- a/src/animation/event.rs
+++ b/src/animation/event.rs
@@ -1,3 +1,6 @@
+//! This module animition event.
+//!
+
 use bevy::{prelude::*, reflect::GetTypeRegistration, utils::HashMap};
 
 use crate::asset::AnimationClip2D;

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -14,7 +14,7 @@ use bevy::{
 
 use self::animation_spritesheet::animation_player_spritesheet;
 
-pub use event::{AnimationEvent, AnimationEventAppExtension};
+pub use event::AnimationEventAppExtension;
 
 /// A [`SystemSet`] to control where the animations are run
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -11,6 +11,7 @@ use bevy::{
     prelude::{App, Component, Handle, IntoSystemConfigs, Plugin, ReflectComponent, SystemSet},
     reflect::Reflect,
 };
+use event::EventTarget;
 
 use self::animation_spritesheet::animation_player_spritesheet;
 
@@ -26,7 +27,8 @@ pub struct AnimationPlayer2DPlugin;
 impl Plugin for AnimationPlayer2DPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<AnimationPlayer2D>()
-            .register_type::<PlayingAnimation2D>();
+            .register_type::<PlayingAnimation2D>()
+            .register_type::<EventTarget>();
         app.add_systems(
             PostUpdate,
             animation_player_spritesheet.in_set(AnimationPlayer2DSystemSet),

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -2,7 +2,7 @@
 //!
 
 mod animation_spritesheet;
-mod event;
+pub mod event;
 
 use crate::prelude::AnimationClip2D;
 use bevy::{

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -14,7 +14,7 @@ use bevy::{
 
 use self::animation_spritesheet::animation_player_spritesheet;
 
-pub use event::AnimationEventAppExtension;
+pub use event::{AnimationEvent, AnimationEventAppExtension};
 
 /// A [`SystemSet`] to control where the animations are run
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -14,7 +14,7 @@ use bevy::{
 
 use self::animation_spritesheet::animation_player_spritesheet;
 
-pub use event::{default_entity, AnimationEvent, AnimationEventAppExtension};
+pub use event::{AnimationEvent, AnimationEventAppExtension};
 
 /// A [`SystemSet`] to control where the animations are run
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -35,11 +35,12 @@ impl Plugin for AnimationPlayer2DPlugin {
 }
 
 #[derive(Reflect)]
-struct PlayingAnimation2D {
+pub(crate) struct PlayingAnimation2D {
     repeat: RepeatAnimation,
     speed: f32,
     elapsed: f32,
-    frame: usize,
+    pub(crate) last_frame: Option<usize>,
+    frame: Option<usize>,
     seek_time: f32,
     animation_clip: Handle<AnimationClip2D>,
     completions: u32,
@@ -52,7 +53,8 @@ impl Default for PlayingAnimation2D {
             repeat: Default::default(),
             speed: 1.0,
             elapsed: 0.0,
-            frame: 0,
+            last_frame: None,
+            frame: None,
             seek_time: 0.0,
             animation_clip: Default::default(),
             completions: 0,
@@ -139,7 +141,7 @@ impl PlayingAnimation2D {
 #[reflect(Component)]
 pub struct AnimationPlayer2D {
     paused: bool,
-    animation: PlayingAnimation2D,
+    pub(crate) animation: PlayingAnimation2D,
 }
 
 impl AnimationPlayer2D {
@@ -266,7 +268,7 @@ impl AnimationPlayer2D {
     ///
     /// This will be the same value as the index of the current animation in the spritesheet.
     pub fn frame(&self) -> usize {
-        self.animation.frame
+        self.animation.frame.unwrap_or(0)
     }
 
     /// Seek time inside of the animation. Always within the range [0.0, clip_duration].

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -14,7 +14,7 @@ use bevy::{
 
 use self::animation_spritesheet::animation_player_spritesheet;
 
-pub use event::{AnimationEvent, AnimationEventAppExtension};
+pub use event::{default_entity, AnimationEvent, AnimationEventAppExtension};
 
 /// A [`SystemSet`] to control where the animations are run
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -2,6 +2,7 @@
 //!
 
 mod animation_spritesheet;
+mod event;
 
 use crate::prelude::AnimationClip2D;
 use bevy::{
@@ -12,6 +13,8 @@ use bevy::{
 };
 
 use self::animation_spritesheet::animation_player_spritesheet;
+
+pub use event::{AnimationEvent, AnimationEventAppExtension};
 
 /// A [`SystemSet`] to control where the animations are run
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/asset/asset_loader.rs
+++ b/src/asset/asset_loader.rs
@@ -1,15 +1,13 @@
 //! This module contains the internals of the Animation2DLoader.
 //!
 
-use std::ops::Range;
-
 use bevy::{
     asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},
     prelude::{AppTypeRegistry, FromWorld, World},
-    reflect::{Reflect, TypeRegistryArc},
+    reflect::TypeRegistryArc,
 };
 use ron::Deserializer;
-use serde::{de::DeserializeSeed, Deserialize};
+use serde::de::DeserializeSeed;
 use thiserror::Error;
 
 use super::{serde::AnimationClip2DSetDeserializer, AnimationClip2DError, AnimationClip2DSet};
@@ -43,36 +41,6 @@ pub enum Animation2DLoaderError {
     AnimationClip2DError(#[from] AnimationClip2DError),
 }
 
-/// Declaration of the deserialized variant for the animation frame indices.
-#[derive(Debug, Deserialize, Reflect)]
-pub(crate) enum TrickfilmEntryKeyframes {
-    /// You can specify the index of each frame seperately.
-    KeyframesVec(Vec<usize>),
-    /// Use this, if the animation frames of an animation have continuous indices.
-    KeyframesRange(Range<usize>),
-}
-
-impl From<TrickfilmEntryKeyframes> for Vec<usize> {
-    fn from(manifest: TrickfilmEntryKeyframes) -> Self {
-        match manifest {
-            TrickfilmEntryKeyframes::KeyframesVec(vec) => vec,
-            TrickfilmEntryKeyframes::KeyframesRange(range) => range.collect(),
-        }
-    }
-}
-
-/// Representation of a loaded trickfilm file.
-#[derive(Debug, Deserialize, Reflect)]
-pub(crate) struct TrickfilmEntry {
-    /// Keyframes of this animation
-    keyframes: TrickfilmEntryKeyframes,
-    /// Keyframe timestamps for this animation
-    #[serde(default)]
-    keyframe_timestamps: Option<Vec<f32>>,
-    /// Duration ofthis animation
-    duration: f32,
-}
-
 /// File extension for spritesheet animation manifest files written in ron.
 const FILE_EXTENSIONS: &[&str] = &["trickfilm.ron", "trickfilm"];
 
@@ -99,43 +67,6 @@ impl AssetLoader for Animation2DLoader {
         Ok(animationclip2dset_deserializer
             .deserialize(&mut deserializer)
             .map_err(|e| deserializer.span_error(e))?)
-
-        /*
-        let trickfilm_entries = ron::de::from_bytes::<HashMap<String, TrickfilmEntry>>(&bytes)?;
-
-        let animations: Result<HashMap<String, Handle<AnimationClip2D>>, AnimationClip2DError> =
-            trickfilm_entries
-                .into_iter()
-                .map(|(name, entry)| {
-                    let duration = entry.duration;
-                    let keyframes: Vec<usize> = entry.keyframes.into();
-                    let keyframe_timestamps = entry.keyframe_timestamps.unwrap_or(
-                        (0..keyframes.len())
-                            .map(|i| {
-                                let i = i as f32 / keyframes.len() as f32;
-                                i * duration
-                            })
-                            .collect(),
-                    );
-
-                    let animation_clip = AnimationClip2D::new(
-                        keyframe_timestamps,
-                        Keyframes::KeyframesVec(keyframes),
-                        duration,
-                        HashMap::new(),
-                    )?;
-                    Ok((
-                        name.clone(),
-                        load_context.add_labeled_asset(name, animation_clip),
-                    ))
-                })
-                .collect();
-
-        let animation_clip_2d_set = AnimationClip2DSet {
-            animations: animations?,
-        };
-        Ok(animation_clip_2d_set)
-        */
     }
 
     fn extensions(&self) -> &[&str] {

--- a/src/asset/asset_loader.rs
+++ b/src/asset/asset_loader.rs
@@ -95,8 +95,12 @@ impl AssetLoader for Animation2DLoader {
                             .collect(),
                     );
 
-                    let animation_clip =
-                        AnimationClip2D::new(keyframe_timestamps, keyframes, duration)?;
+                    let animation_clip = AnimationClip2D::new(
+                        keyframe_timestamps,
+                        keyframes,
+                        duration,
+                        HashMap::new(),
+                    )?;
                     Ok((
                         name.clone(),
                         load_context.add_labeled_asset(name, animation_clip),

--- a/src/asset/asset_loader.rs
+++ b/src/asset/asset_loader.rs
@@ -1,7 +1,7 @@
 //! This module contains the internals of the Animation2DLoader.
 //!
 
-use std::ops::{DerefMut, Range};
+use std::ops::Range;
 
 use bevy::{
     asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext},

--- a/src/asset/asset_loader.rs
+++ b/src/asset/asset_loader.rs
@@ -12,7 +12,7 @@ use bevy::{
 use serde::Deserialize;
 use thiserror::Error;
 
-use super::{AnimationClip2D, AnimationClip2DError, AnimationClip2DSet};
+use super::{AnimationClip2D, AnimationClip2DError, AnimationClip2DSet, Keyframes};
 
 #[derive(Default)]
 pub(crate) struct Animation2DLoader;
@@ -97,7 +97,7 @@ impl AssetLoader for Animation2DLoader {
 
                     let animation_clip = AnimationClip2D::new(
                         keyframe_timestamps,
-                        keyframes,
+                        Keyframes::KeyframesVec(keyframes),
                         duration,
                         HashMap::new(),
                     )?;

--- a/src/asset/mod.rs
+++ b/src/asset/mod.rs
@@ -31,9 +31,12 @@ impl Plugin for Animation2DLoaderPlugin {
     }
 }
 
+/// Keyframes, either as an ordered list or range of texture atlas indices.
 #[derive(Debug, Deserialize)]
 pub enum Keyframes {
+    /// Ordered list of texture atlas indices.
     KeyframesVec(Vec<usize>),
+    /// Range of texture atlas indices.
     KeyframesRange(Range<usize>),
 }
 
@@ -47,6 +50,8 @@ impl From<Keyframes> for Vec<usize> {
 }
 
 impl Keyframes {
+    /// Returns the number of keyframes, also referred to
+    /// as its 'length'.
     pub fn len(&self) -> usize {
         match self {
             Keyframes::KeyframesVec(vec) => vec.len(),
@@ -54,6 +59,7 @@ impl Keyframes {
         }
     }
 
+    /// Returns `true` if there are no keyframes.
     pub fn is_empty(&self) -> bool {
         match self {
             Keyframes::KeyframesVec(vec) => vec.is_empty(),
@@ -61,10 +67,20 @@ impl Keyframes {
         }
     }
 
+    /// Returns the keyframe at the given index.
+    ///
+    /// - Returns `None` if index is out of bounds.
     pub fn get(&self, index: usize) -> Option<usize> {
         match self {
-            Keyframes::KeyframesVec(vec) => Some(vec[index]),
-            Keyframes::KeyframesRange(range) => Some(range.start + index),
+            Keyframes::KeyframesVec(vec) => vec.get(index).copied(),
+            Keyframes::KeyframesRange(range) => {
+                let value = range.start + index;
+                if value < range.end {
+                    Some(value)
+                } else {
+                    None
+                }
+            }
         }
     }
 }
@@ -167,7 +183,7 @@ impl AnimationClip2D {
         &self.keyframe_timestamps
     }
 
-    /// Ordered list of keyframes for this animation.
+    /// Keyframes for this animation.
     #[inline]
     pub fn keyframes(&self) -> &Keyframes {
         &self.keyframes

--- a/src/asset/mod.rs
+++ b/src/asset/mod.rs
@@ -45,7 +45,7 @@ pub struct AnimationClip2D {
     keyframes: Vec<usize>,
     /// Total duration of this animation clip in seconds.
     duration: f32,
-    pub events: HashMap<usize, Vec<Box<dyn Reflect>>>,
+    events: HashMap<usize, Vec<Box<dyn Reflect>>>,
 }
 
 /// Possible errors that can be produced by [`AnimationClip2D`]
@@ -61,6 +61,9 @@ pub enum AnimationClip2DError {
     /// Error that occurs, if duration is not sufficient to play all keyframes.
     #[error("Duration of {0} is insufficient to display last keyframe at {1}")]
     InsufficientDuration(f32, f32),
+    /// Error that occurs, if an events references a frame outside the frame range.
+    #[error("Frame {0} for this animation clip, because it only has {1} frames")]
+    InvalidFrame(usize, usize),
 }
 
 impl AnimationClip2D {
@@ -98,6 +101,14 @@ impl AnimationClip2D {
             ));
         }
 
+        let max_event_frame = events.keys().max().cloned().unwrap_or(0);
+        if max_event_frame > keyframes_len {
+            return Err(AnimationClip2DError::InvalidFrame(
+                max_event_frame,
+                keyframes_len,
+            ));
+        }
+
         Ok(Self {
             keyframe_timestamps,
             keyframes,
@@ -122,6 +133,12 @@ impl AnimationClip2D {
     #[inline]
     pub fn duration(&self) -> f32 {
         self.duration
+    }
+
+    /// All reflected events for this animation clip identified by their associated frame.
+    #[inline]
+    pub fn events(&self) -> &HashMap<usize, Vec<Box<dyn Reflect>>> {
+        &self.events
     }
 }
 

--- a/src/asset/mod.rs
+++ b/src/asset/mod.rs
@@ -9,7 +9,7 @@ use std::cmp::Ordering;
 use asset_loader::{TrickfilmEntry, TrickfilmEntryKeyframes};
 use bevy::{
     prelude::{App, Asset, AssetApp, Handle, Plugin},
-    reflect::Reflect,
+    reflect::{Reflect, TypePath},
     utils::HashMap,
 };
 use thiserror::Error;
@@ -23,8 +23,11 @@ pub struct Animation2DLoaderPlugin;
 
 impl Plugin for Animation2DLoaderPlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<AnimationClip2D>()
+        app
+            /*
+            .register_type::<AnimationClip2D>()
             .register_type::<AnimationClip2DSet>()
+            */
             .register_type::<TrickfilmEntryKeyframes>()
             .register_type::<TrickfilmEntry>();
         app.init_asset::<AnimationClip2D>()
@@ -34,7 +37,7 @@ impl Plugin for Animation2DLoaderPlugin {
 }
 
 /// AnimationClip for a 2D animation.
-#[derive(Asset, Reflect, Clone, Debug, Default)]
+#[derive(Asset, TypePath, Debug)]
 pub struct AnimationClip2D {
     /// Timestamps for each keyframe in seconds.
     keyframe_timestamps: Vec<f32>,
@@ -42,6 +45,7 @@ pub struct AnimationClip2D {
     keyframes: Vec<usize>,
     /// Total duration of this animation clip in seconds.
     duration: f32,
+    pub events: HashMap<usize, Vec<Box<dyn Reflect>>>,
 }
 
 /// Possible errors that can be produced by [`AnimationClip2D`]
@@ -97,6 +101,7 @@ impl AnimationClip2D {
             keyframe_timestamps,
             keyframes,
             duration,
+            events: HashMap::new(),
         })
     }
 
@@ -120,7 +125,7 @@ impl AnimationClip2D {
 }
 
 /// Set(Map) of AnimationClips for a 2D animation.
-#[derive(Asset, Reflect, Clone, Debug, Default)]
+#[derive(Asset, TypePath, Debug)]
 pub struct AnimationClip2DSet {
     /// Named animations loaded from the trickfilm file.
     pub animations: HashMap<String, Handle<AnimationClip2D>>,

--- a/src/asset/mod.rs
+++ b/src/asset/mod.rs
@@ -69,6 +69,7 @@ impl AnimationClip2D {
         keyframe_timestamps: Vec<f32>,
         keyframes: Vec<usize>,
         duration: f32,
+        events: HashMap<usize, Vec<Box<dyn Reflect>>>,
     ) -> Result<Self, AnimationClip2DError> {
         let keyframe_timestamps_len = keyframe_timestamps.len();
         let keyframes_len = keyframes.len();
@@ -101,7 +102,7 @@ impl AnimationClip2D {
             keyframe_timestamps,
             keyframes,
             duration,
-            events: HashMap::new(),
+            events,
         })
     }
 

--- a/src/asset/mod.rs
+++ b/src/asset/mod.rs
@@ -110,13 +110,23 @@ pub enum AnimationClip2DError {
 impl AnimationClip2D {
     /// Creates a valid [`AnimationClip2D`]
     pub fn new(
-        keyframe_timestamps: Vec<f32>,
+        keyframe_timestamps: Option<Vec<f32>>,
         keyframes: Keyframes,
         duration: f32,
-        events: HashMap<usize, Vec<Box<dyn Reflect>>>,
+        events: Option<HashMap<usize, Vec<Box<dyn Reflect>>>>,
     ) -> Result<Self, AnimationClip2DError> {
-        let keyframe_timestamps_len = keyframe_timestamps.len();
         let keyframes_len = keyframes.len();
+
+        let keyframe_timestamps = keyframe_timestamps.unwrap_or(
+            (0..keyframes_len)
+                .map(|i| {
+                    let i = i as f32 / keyframes_len as f32;
+                    i * duration
+                })
+                .collect(),
+        );
+
+        let keyframe_timestamps_len = keyframe_timestamps.len();
         if keyframe_timestamps_len != keyframes_len {
             return Err(AnimationClip2DError::SizeMismatch(
                 keyframe_timestamps_len,
@@ -142,6 +152,7 @@ impl AnimationClip2D {
             ));
         }
 
+        let events = events.unwrap_or_default();
         let max_event_frame = events.keys().max().cloned().unwrap_or(0);
         if max_event_frame > keyframes_len {
             return Err(AnimationClip2DError::InvalidFrame(

--- a/src/asset/mod.rs
+++ b/src/asset/mod.rs
@@ -162,7 +162,7 @@ impl AnimationClip2D {
 
         let events = events.unwrap_or_default();
         let max_event_frame = events.keys().max().cloned().unwrap_or(0);
-        if max_event_frame > keyframes_len {
+        if max_event_frame >= keyframes_len {
             return Err(AnimationClip2DError::InvalidFrame(
                 max_event_frame,
                 keyframes_len,

--- a/src/asset/mod.rs
+++ b/src/asset/mod.rs
@@ -8,7 +8,6 @@ use std::cmp::Ordering;
 use std::ops::Range;
 
 use ::serde::Deserialize;
-use asset_loader::{TrickfilmEntry, TrickfilmEntryKeyframes};
 use bevy::{
     prelude::{App, Asset, AssetApp, Handle, Plugin},
     reflect::{Reflect, TypePath},
@@ -26,13 +25,6 @@ pub struct Animation2DLoaderPlugin;
 
 impl Plugin for Animation2DLoaderPlugin {
     fn build(&self, app: &mut App) {
-        app
-            /*
-            .register_type::<AnimationClip2D>()
-            .register_type::<AnimationClip2DSet>()
-            */
-            .register_type::<TrickfilmEntryKeyframes>()
-            .register_type::<TrickfilmEntry>();
         app.init_asset::<AnimationClip2D>()
             .init_asset::<AnimationClip2DSet>()
             .init_asset_loader::<Animation2DLoader>();

--- a/src/asset/mod.rs
+++ b/src/asset/mod.rs
@@ -62,6 +62,13 @@ impl Keyframes {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Keyframes::KeyframesVec(vec) => vec.is_empty(),
+            Keyframes::KeyframesRange(range) => range.is_empty(),
+        }
+    }
+
     pub fn get(&self, index: usize) -> Option<usize> {
         match self {
             Keyframes::KeyframesVec(vec) => Some(vec[index]),

--- a/src/asset/serde.rs
+++ b/src/asset/serde.rs
@@ -1,21 +1,41 @@
-use bevy::{asset::LoadContext, reflect::TypeRegistry};
+use bevy::{asset::LoadContext, reflect::TypeRegistry, utils::HashMap};
 use serde::{de::DeserializeSeed, Deserializer};
 
 use super::{AnimationClip2D, AnimationClip2DSet};
 
-pub struct AnimationClip2DSetDeserializer<'a> {
+pub struct AnimationClip2DSetDeserializer<'a, 'l> {
     pub type_registry: &'a TypeRegistry,
-    pub load_context: &'a mut LoadContext<'a>,
+    pub load_context: &'a mut LoadContext<'l>,
 }
 
-impl<'a, 'de> DeserializeSeed<'de> for AnimationClip2DSetDeserializer<'a> {
+impl<'a, 'l, 'de> DeserializeSeed<'de> for AnimationClip2DSetDeserializer<'a, 'l> {
     type Value = AnimationClip2DSet;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
     where
         D: Deserializer<'de>,
     {
-        todo!()
+        /* Essentially a map */
+        /* Deserialize a HashMap with String keys -> delegate to AnimationClip2DDeserializer for values */
+        /* -> use load_context to get Handles from it */
+        let hash_map: HashMap<String, AnimationClip2D> = HashMap::new();
+
+        let animation2dclip_deserializer = AnimationClip2DDeserializer {
+            type_registry: &self.type_registry,
+        };
+        let _ = animation2dclip_deserializer.deserialize(deserializer);
+
+        Ok(AnimationClip2DSet {
+            animations: hash_map
+                .into_iter()
+                .map(|(name, clip)| {
+                    (
+                        name.clone(),
+                        self.load_context.add_labeled_asset(name, clip),
+                    )
+                })
+                .collect(),
+        })
     }
 }
 
@@ -30,6 +50,12 @@ impl<'a, 'de> DeserializeSeed<'de> for AnimationClip2DDeserializer<'a> {
     where
         D: Deserializer<'de>,
     {
+        /* Essentially a struct */
+        /* mandatory keyframes of type Keyframes */
+        /* optional keyframe_timestamps of type Vec<usize> */
+        /* mandatory duration of type f32 */
+        /* optional events of type Box<dyn Reflect> -> use type_registry to reflect the information */
+
         todo!()
     }
 }

--- a/src/asset/serde.rs
+++ b/src/asset/serde.rs
@@ -1,0 +1,35 @@
+use bevy::{asset::LoadContext, reflect::TypeRegistry};
+use serde::{de::DeserializeSeed, Deserializer};
+
+use super::{AnimationClip2D, AnimationClip2DSet};
+
+pub struct AnimationClip2DSetDeserializer<'a> {
+    pub type_registry: &'a TypeRegistry,
+    pub load_context: &'a mut LoadContext<'a>,
+}
+
+impl<'a, 'de> DeserializeSeed<'de> for AnimationClip2DSetDeserializer<'a> {
+    type Value = AnimationClip2DSet;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!()
+    }
+}
+
+pub struct AnimationClip2DDeserializer<'a> {
+    pub type_registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> DeserializeSeed<'de> for AnimationClip2DDeserializer<'a> {
+    type Value = AnimationClip2D;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!()
+    }
+}

--- a/src/asset/serde.rs
+++ b/src/asset/serde.rs
@@ -1,7 +1,10 @@
 use bevy::{asset::LoadContext, reflect::TypeRegistry, utils::HashMap};
-use serde::{de::DeserializeSeed, Deserializer};
+use serde::{
+    de::{DeserializeSeed, Error, Visitor},
+    Deserialize, Deserializer,
+};
 
-use super::{AnimationClip2D, AnimationClip2DSet};
+use super::{AnimationClip2D, AnimationClip2DSet, Keyframes};
 
 pub struct AnimationClip2DSetDeserializer<'a, 'l> {
     pub type_registry: &'a TypeRegistry,
@@ -18,24 +21,40 @@ impl<'a, 'l, 'de> DeserializeSeed<'de> for AnimationClip2DSetDeserializer<'a, 'l
         /* Essentially a map */
         /* Deserialize a HashMap with String keys -> delegate to AnimationClip2DDeserializer for values */
         /* -> use load_context to get Handles from it */
-        let hash_map: HashMap<String, AnimationClip2D> = HashMap::new();
-
-        let animation2dclip_deserializer = AnimationClip2DDeserializer {
-            type_registry: &self.type_registry,
-        };
-        let _ = animation2dclip_deserializer.deserialize(deserializer);
-
-        Ok(AnimationClip2DSet {
-            animations: hash_map
-                .into_iter()
-                .map(|(name, clip)| {
-                    (
-                        name.clone(),
-                        self.load_context.add_labeled_asset(name, clip),
-                    )
-                })
-                .collect(),
+        deserializer.deserialize_map(AnimationClip2DSetMapVisitor {
+            type_registry: self.type_registry,
+            load_context: self.load_context,
         })
+    }
+}
+
+struct AnimationClip2DSetMapVisitor<'a, 'l> {
+    pub type_registry: &'a TypeRegistry,
+    pub load_context: &'a mut LoadContext<'l>,
+}
+
+impl<'a, 'l, 'de> Visitor<'de> for AnimationClip2DSetMapVisitor<'a, 'l> {
+    type Value = AnimationClip2DSet;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("map of clips")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let mut value = HashMap::new();
+
+        while let Some(name) = map.next_key::<String>()? {
+            let clip = map.next_value_seed(AnimationClip2DDeserializer {
+                type_registry: self.type_registry,
+            })?;
+            let asset = self.load_context.add_labeled_asset(name.clone(), clip);
+            value.insert(name, asset);
+        }
+
+        Ok(AnimationClip2DSet { animations: value })
     }
 }
 
@@ -55,7 +74,82 @@ impl<'a, 'de> DeserializeSeed<'de> for AnimationClip2DDeserializer<'a> {
         /* optional keyframe_timestamps of type Vec<usize> */
         /* mandatory duration of type f32 */
         /* optional events of type Box<dyn Reflect> -> use type_registry to reflect the information */
-
-        todo!()
+        deserializer.deserialize_struct(
+            "AnimationClip2D",
+            &["keyframe_timestamps", "keyframes", "duration", "events"],
+            AnimationClip2DVisitor {
+                type_registry: self.type_registry,
+            },
+        )
     }
+}
+
+struct AnimationClip2DVisitor<'a> {
+    pub type_registry: &'a TypeRegistry,
+}
+
+impl<'a, 'de> Visitor<'de> for AnimationClip2DVisitor<'a> {
+    type Value = AnimationClip2D;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("struct of animation 2d clip")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let mut keyframes = None;
+        let mut keyframe_timestamps = None;
+        let mut duration = None;
+        let mut events = None;
+
+        while let Some(key) = map.next_key()? {
+            match key {
+                AnimationClip2DField::Keyframes => {
+                    if keyframes.is_some() {
+                        return Err(Error::duplicate_field("keyframes"));
+                    }
+                    keyframes = Some(map.next_value::<Keyframes>()?);
+                }
+                AnimationClip2DField::KeyframeTimestamps => {
+                    if keyframe_timestamps.is_some() {
+                        return Err(Error::duplicate_field("keyframe_timestamps"));
+                    }
+                    keyframe_timestamps = Some(map.next_value::<Vec<f32>>()?);
+                }
+                AnimationClip2DField::Duration => {
+                    if duration.is_some() {
+                        return Err(Error::duplicate_field("duration"));
+                    }
+                    duration = Some(map.next_value::<f32>()?);
+                }
+                AnimationClip2DField::Events => {
+                    if events.is_some() {
+                        return Err(Error::duplicate_field("events"));
+                    }
+                    /* TODO */
+                }
+            }
+        }
+
+        let keyframes = keyframes.ok_or_else(|| Error::missing_field("keyframes"))?;
+        let duration = duration.ok_or_else(|| Error::missing_field("duration"))?;
+
+        AnimationClip2D::new(keyframe_timestamps, keyframes, duration, events)
+            .map_err(Error::custom)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(field_identifier)]
+enum AnimationClip2DField {
+    #[serde(rename = "keyframes")]
+    Keyframes,
+    #[serde(rename = "keyframe_timestamps")]
+    KeyframeTimestamps,
+    #[serde(rename = "duration")]
+    Duration,
+    #[serde(rename = "events")]
+    Events,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ impl Plugin for Animation2DPlugin {
 
 /// `use bevy_trickfilm::prelude::*;` to import common components and plugins.
 pub mod prelude {
-    pub use crate::animation::AnimationEventAppExtension;
+    pub use crate::animation::{AnimationEvent, AnimationEventAppExtension};
     pub use crate::animation::{
         AnimationPlayer2D, AnimationPlayer2DPlugin, AnimationPlayer2DSystemSet,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ impl Plugin for Animation2DPlugin {
 
 /// `use bevy_trickfilm::prelude::*;` to import common components and plugins.
 pub mod prelude {
-    pub use crate::animation::{AnimationEvent, AnimationEventAppExtension};
+    pub use crate::animation::{default_entity, AnimationEvent, AnimationEventAppExtension};
     pub use crate::animation::{
         AnimationPlayer2D, AnimationPlayer2DPlugin, AnimationPlayer2DSystemSet,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ impl Plugin for Animation2DPlugin {
 
 /// `use bevy_trickfilm::prelude::*;` to import common components and plugins.
 pub mod prelude {
-    pub use crate::animation::{AnimationEvent, AnimationEventAppExtension};
+    pub use crate::animation::AnimationEventAppExtension;
     pub use crate::animation::{
         AnimationPlayer2D, AnimationPlayer2DPlugin, AnimationPlayer2DSystemSet,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ impl Plugin for Animation2DPlugin {
 
 /// `use bevy_trickfilm::prelude::*;` to import common components and plugins.
 pub mod prelude {
+    pub use crate::animation::{AnimationEvent, AnimationEventAppExtension};
     pub use crate::animation::{
         AnimationPlayer2D, AnimationPlayer2DPlugin, AnimationPlayer2DSystemSet,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,4 +27,5 @@ pub mod prelude {
     };
     pub use crate::asset::{Animation2DLoaderPlugin, AnimationClip2D, AnimationClip2DSet};
     pub use crate::Animation2DPlugin;
+    pub use bevy_trickfilm_derive::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ impl Plugin for Animation2DPlugin {
 
 /// `use bevy_trickfilm::prelude::*;` to import common components and plugins.
 pub mod prelude {
-    pub use crate::animation::{default_entity, AnimationEvent, AnimationEventAppExtension};
+    pub use crate::animation::{AnimationEvent, AnimationEventAppExtension};
     pub use crate::animation::{
         AnimationPlayer2D, AnimationPlayer2DPlugin, AnimationPlayer2DSystemSet,
     };


### PR DESCRIPTION
Add arbitrary targeted and non-targeted events
Events will be send multiple times right now, because the frame transition is not debounced (will be fixed)

How to use:
In your code create an Event as usual, adding it to the app
Additional derive Reflect and register the type
Additional implement AnimationEvent
For targeted events, you need to reflect skip_serialization on the entity member and impl set_entity of AnimationEvent
Add your event using either add_animation_event/add_animation_trigger