### PR TITLE
Add play_continue to keep frame state

### DIFF
--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -149,19 +149,40 @@ pub struct AnimationPlayer2D {
 }
 
 impl AnimationPlayer2D {
-    /// Start playing an animation, resetting state of the player.
-    pub fn start(&mut self, handle: Handle<AnimationClip2D>) -> &mut Self {
+    fn start_from_time(
+        &mut self,
+        handle: Handle<AnimationClip2D>,
+        elapsed: f32,
+        seek_time: f32,
+    ) -> &mut Self {
         self.animation = PlayingAnimation2D {
             animation_clip: handle,
+            elapsed,
+            seek_time,
             ..Default::default()
         };
         self
+    }
+
+    /// Start playing an animation, resetting state of the player.
+    pub fn start(&mut self, handle: Handle<AnimationClip2D>) -> &mut Self {
+        self.start_from_time(handle, 0.0, 0.0)
     }
 
     /// Start playing an animation, resetting state of the player, unless the requested animation is already playing.
     pub fn play(&mut self, handle: Handle<AnimationClip2D>) -> &mut Self {
         if self.animation.animation_clip != handle || self.paused() {
             self.start(handle);
+        }
+        self
+    }
+
+    /// Start playing an animation from the current `seek_time` and `elapsed` state.
+    ///
+    /// This should only be called on animations that have the same duration.
+    pub fn play_continue(&mut self, handle: Handle<AnimationClip2D>) -> &mut Self {
+        if self.animation.animation_clip != handle || self.paused() {
+            self.start_from_time(handle, self.animation.elapsed, self.animation.seek_time);
         }
         self
     }


### PR DESCRIPTION
As I understand it `seek_time` will wrap based on the `duration` of the current animation. This means that when we play say an idle with 30 frames and then the user transitions to a punch with only 5 frames (which he shouldn't with this new feature but well let's say he makes an oopsie) then all that will happen is that the current frame is either in range (i.e. <5 frames), or if it is >=5 frames it will just immediately wrap to 0 frames?

At least that's how I understand it and also what I observed in a little test. I was thinking it may crash or something with an index out of bounds but seems like it works fine and there is no need for further error handling. Though would like you to take a look at this.

Also open for naming suggestions.